### PR TITLE
Allow configure logging to file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *~
+/*.log
 /.idea/
 /config/config.php
 /vendor/

--- a/config/config.dist.php
+++ b/config/config.dist.php
@@ -68,5 +68,8 @@ return [
 //        | SMARTIRC_DEBUG_MODULES
 //        | SMARTIRC_DEBUG_USERSYNCING
 
+    // SmartIRC logger, defaults to stdout
+//    'logging.smartirc' => 'irc_bot_smartirc.log',
+
     'default_category' => 'default',
 ];

--- a/config/config.dist.php
+++ b/config/config.dist.php
@@ -71,5 +71,8 @@ return [
     // SmartIRC logger, defaults to stdout
 //    'logging.smartirc' => 'irc_bot_smartirc.log',
 
+    // PHP error logs, defaults to php.ini defaults
+//    'logging.errorlog' => 'irc_bot_error.log',
+
     'default_category' => 'default',
 ];

--- a/src/Config.php
+++ b/src/Config.php
@@ -119,6 +119,8 @@ class Config implements ArrayAccess, IteratorAggregate
 
             // SmartIRC logger
             'logging.smartirc' => null,
+            // PHP error logs
+            'logging.errorlog' => null,
 
             'default_category' => 'default',
         ]);

--- a/src/Config.php
+++ b/src/Config.php
@@ -117,6 +117,9 @@ class Config implements ArrayAccess, IteratorAggregate
 
             'debugLevel' => 0,
 
+            // SmartIRC logger
+            'logging.smartirc' => null,
+
             'default_category' => 'default',
         ]);
 

--- a/src/IrcBot.php
+++ b/src/IrcBot.php
@@ -61,6 +61,11 @@ class IrcBot
         if ($config['debugLevel']) {
             $irc->setDebugLevel($config['debugLevel']);
         }
+
+        if ($config['logging.smartirc']) {
+            $irc->setLogDestination(SMARTIRC_FILE);
+            $irc->setLogFile($config['logging.smartirc']);
+        }
     }
 
     private function login(Net_SmartIRC $irc, Config $config)

--- a/src/IrcBot.php
+++ b/src/IrcBot.php
@@ -66,6 +66,12 @@ class IrcBot
             $irc->setLogDestination(SMARTIRC_FILE);
             $irc->setLogFile($config['logging.smartirc']);
         }
+
+        if ($config['logging.errorlog']) {
+            // this will redirect stderr to a logfile
+            ini_set('log_errors', 'On');
+            ini_set('error_log', $config['logging.errorlog']);
+        }
     }
 
     private function login(Net_SmartIRC $irc, Config $config)


### PR DESCRIPTION
Default logging goes to terminal, nice for debugging. In actual deployment needed to log to file.