### PR TITLE
make eventum events polling configurable (via events.poll_interval)

### DIFF
--- a/config/config.dist.php
+++ b/config/config.dist.php
@@ -51,7 +51,10 @@ return [
         'Default Project' => '#issues',
     ],
 
-    /**
+    // default category for events without it
+    'default_category' => 'default',
+
+    /*
      * Bitwise debug level out of SMARTIRC_DEBUG_* constants
      *
      * @see Net_SmartIRC::setDebugLevel
@@ -81,6 +84,4 @@ return [
 
     // PHP error logs, defaults to php.ini defaults
 //    'logging.errorlog' => 'irc_bot_error.log',
-
-    'default_category' => 'default',
 ];

--- a/src/Config.php
+++ b/src/Config.php
@@ -114,6 +114,7 @@ class Config implements ArrayAccess, IteratorAggregate
             'channels' => [
                 'Default Project' => '#issues',
             ],
+            'default_category' => 'default',
 
             'debugLevel' => 0,
 
@@ -122,7 +123,8 @@ class Config implements ArrayAccess, IteratorAggregate
             // PHP error logs
             'logging.errorlog' => null,
 
-            'default_category' => 'default',
+            // in milliseconds, how often to pull events from xmlrpc
+            'events.poll_interval' => 3000,
         ]);
 
         $resolver->setAllowedTypes('channels', 'array');

--- a/src/Event/EventumEventsListener.php
+++ b/src/Event/EventumEventsListener.php
@@ -54,7 +54,8 @@ class EventumEventsListener extends BaseCommand implements EventListenerInterfac
             return;
         }
 
-        $irc->registerTimeHandler(3000, $this, 'notifyEvents');
+        $pollInterval = $this->config['events.poll_interval'];
+        $irc->registerTimeHandler($pollInterval, $this, 'notifyEvents');
     }
 
     private function getProjects()


### PR DESCRIPTION
default polling is 3 seconds. maybe too often for slow activity in tracker. allow change interval via config (advanced setting, so not included in example config).